### PR TITLE
Add baseurl to _config.yml

### DIFF
--- a/www/_config.yml
+++ b/www/_config.yml
@@ -3,6 +3,7 @@ markdown: redcarpet
 highlighter: pygments
 
 url: "https://www.noname-ev.de"
+baseurl: ""
 
 treff_lat: 49.417433
 treff_lon: 8.675255


### PR DESCRIPTION
Jekyll now defaults baseurl to nil instead of empty string: https://github.com/jekyll/jekyll/pull/6137
This causes builds to break, because the sitemap plugin uses it to build URLs: https://github.com/nnev/website/blob/cd9cc1d6982bc18acda5f72a11957b9ffe0172b0/www/_plugins/sitemap_generator.rb#L184

A better long-term fix is to get a new version of the sitemap plugin, but for now, let's just overwrite the default explicitly to fix the build.