### PR TITLE
Fix several issues regarding the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 # TODO: install as debian package once available
 RUN	gem install icalendar
 
-ENV PGUSER=postgres PGHOST=localhost
+ENV PGUSER=postgres PGHOST=postgres
 # tell jekyll to use utf-8 (website build fails otherwise)
 ENV LC_ALL=C.UTF-8
 ENV GOPATH=/tmp/go

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 .DEFAULT_GOAL := website
 
 postgres:
-	docker run -d --name=nnev-postgres -p 127.0.0.1:5432:5432 postgres | exit 0
+	docker run -d --name=nnev-postgres postgres | exit 0
 
 website: postgres
 	docker rm -f nnev-website | exit 0
 	docker build --force-rm -t nnev-website .
-	docker run --name=nnev-website --net=host -p 127.0.0.1:80:80 -v "$(shell pwd):/usr/src/" nnev-website
+	docker run --name=nnev-website -p 127.0.0.1:8080:80 --link nnev-postgres:postgres -v "$(shell pwd):/usr/src/" nnev-website
 
 stop:
 	docker rm -f nnev-website
@@ -22,4 +22,4 @@ purge: clean
 	docker rmi -f nnev-postgres | exit 0
 
 open:
-	xdg-open http://127.0.0.1:80
+	xdg-open http://127.0.0.1:8080

--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@
 
 ### use the Makefile
 
-  * run `make`
-  * browse to [`127.0.0.1:80`](http://127.0.0.1:80) or issue `make open` beforehand
-  * when you are done, `Ctrl-C` out and rerun `make` to update the testinstance with your new changes
+  * make sure there are no running services on the port 8080, otherwise change the port in the `Makefile`
+  * run `make` (with docker privileges, e.g. as root)
+  * browse to [`127.0.0.1:8080`](http://127.0.0.1:8080) or issue `make open` beforehand
+  * when you are done, `Ctrl-C` out and rerun `make` to update the test instance with your new changes
 
 After testing your changes, `make clean` provides a convenient way to clean up after you, stopping and removing all the containers you have created in the process of testing.
-If you want to get rid of remainers of the process: `make clean` removes all containers, `make purge` removes all containers including all images (be aware that they need to be redownloaded and such next time you test the website, so you probably usually do not want to issue a `make purge` unless you are in severe need of disk space).
+If you want to get rid of remainders of the process: `make clean` removes all containers, `make purge` removes all containers including all images (be aware that they need to be redownloaded and such next time you test the website, so you probably usually do not want to issue a `make purge` unless you are in severe need of disk space).
 
-### run testenvironement manually
+### run test environment manually
 
-  * start postgresql: `docker run -p 127.0.0.1:5432:5432 postgres`
+  * start postgresql: `docker run -d --name=nnev-postgres postgres`
   * build website: `docker build -t nnev-website .`
-  * run website: `docker run --name=nnev-website --net=host -p 127.0.0.1:80:80 -v $PWD:/usr/src/ nnev-website`
-  * browse to [`127.0.0.1:80`](http://127.0.0.1:80) to inspect your state of the webpage
+  * run website: `docker run --name=nnev-website -p 127.0.0.1:8080:80 --link nnev-postgres:postgres -v $PWD:/usr/src/ nnev-website`
+  * browse to [`127.0.0.1:8080`](http://127.0.0.1:8080) to inspect your state of the webpage
   * restart: `Ctrl-C` out and run `docker kill nnev-website; docker rm nnev-website`, then goto `run website`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,6 @@ go install github.com/nnev/website/...
 cd /tmp/go/src/github.com/nnev/website/www
 createdb nnev || true
 ./_createdb.sh
-termine -hook=/build_website.sh -connect="dbname=nnev host=localhost sslmode=disable" next 4
+termine -hook=/build_website.sh -connect="dbname=nnev host=$PGHOST sslmode=disable" next 4
 jekyll build
 exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/nnev-website-supervisor.conf
+++ b/nnev-website-supervisor.conf
@@ -5,13 +5,13 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:c14h]
-command=/tmp/go/bin/c14h -template=/tmp/go/src/github.com/nnev/website/www/_site/edit_c14.html -listen=localhost:6725 -connect="dbname=nnev host=localhost sslmode=disable" -hook=/build_website.sh
+command=/tmp/go/bin/c14h -template=/tmp/go/src/github.com/nnev/website/www/_site/edit_c14.html -listen=localhost:6725 -connect="dbname=nnev host=%(ENV_PGHOST)s sslmode=disable" -hook=/build_website.sh
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:yarpnarp]
-command=/tmp/go/bin/yarpnarp -template=/tmp/go/src/github.com/nnev/website/www/_site/yarpnarp.html -listen=localhost:5417 -connect="dbname=nnev host=localhost sslmode=disable" -hook=/build_website.sh
+command=/tmp/go/bin/yarpnarp -template=/tmp/go/src/github.com/nnev/website/www/_site/yarpnarp.html -listen=localhost:5417 -connect="dbname=nnev host=%(ENV_PGHOST)s sslmode=disable" -hook=/build_website.sh
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
prevent and fixes #95

If the files `entrypoint.sh` or `nnev-website-supervisor.conf` are used in the actual deployment, `PGHOST` has to be set in the deployment process on the production machine.