### PR TITLE
Introduce an isolated user inside dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,20 @@ ENV PATH="/tmp/go/bin:${PATH}"
 # needed for hook service
 ENV WEBHOOK_SECRET=geheim
 
-WORKDIR /tmp/go/src/github.com/nnev/website/
-COPY . .
-
 ADD build_entrypoint.sh /build_entrypoint.sh
 ADD entrypoint.sh /entrypoint.sh
 ADD build_website.sh /build_website.sh
 ADD nnev-website-nginx.conf /etc/nginx/sites-available/default
 ADD nnev-website-supervisor.conf /etc/supervisor/conf.d/supervisord.conf
 
-RUN go get -v ./...
-RUN go install -v ./...
+RUN useradd -ms /bin/bash nnev
+WORKDIR /tmp/go/src/github.com/nnev/website/
+COPY . .
+
+# Dockerfiles's ADD/COPY has a --chown arguments but no --chmod argument.
+RUN chown -R nnev:nnev "${GOPATH}" && chmod -R a+rX "${GOPATH}"
+RUN runuser -u nnev -- go get -v ./...
+RUN runuser -u nnev -- go install -v ./...
 
 EXPOSE 80
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 cd /tmp/go/src/github.com/nnev/website/www
-termine -hook=/build_website.sh -connect="dbname=nnev host=$PGHOST sslmode=disable" next 4
-jekyll build
+runuser -u nnev -- termine -hook=/build_website.sh -connect="dbname=nnev host=$PGHOST sslmode=disable" next 4
+runuser -u nnev -- jekyll build
 exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/nnev-website-supervisor.conf
+++ b/nnev-website-supervisor.conf
@@ -6,18 +6,21 @@ stdout_logfile_maxbytes=0
 
 [program:c14h]
 command=/tmp/go/bin/c14h -template=/tmp/go/src/github.com/nnev/website/www/_site/edit_c14.html -listen=localhost:6725 -connect="dbname=nnev host=%(ENV_PGHOST)s sslmode=disable" -hook=/build_website.sh
+user=nnev
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:yarpnarp]
 command=/tmp/go/bin/yarpnarp -template=/tmp/go/src/github.com/nnev/website/www/_site/yarpnarp.html -listen=localhost:5417 -connect="dbname=nnev host=%(ENV_PGHOST)s sslmode=disable" -hook=/build_website.sh
+user=nnev
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:hook]
 command=/tmp/go/bin/hook -listen=localhost:5221 -hook=/build_website.sh
+user=nnev
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Previously all commands where executed as root inside the docker
container. Supervisord has started all service as root, too.

Even though the docker container provides a level of isolation, code
should still be executed with the least required privileges.

Comments or suggestions are welcome :)