### PR TITLE
Fix #70: Respect PG* environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 # TODO: install as debian package once available
 RUN gem install icalendar
 
-ENV PGUSER=postgres PGHOST=postgres
+ENV PGUSER=postgres PGHOST=postgres PGDATABASE=nnev PGSSLMODE=disable
 # tell jekyll to use utf-8 (website build fails otherwise)
 ENV LC_ALL=C.UTF-8
 ENV GOPATH=/tmp/go

--- a/c14h/db_port.go
+++ b/c14h/db_port.go
@@ -15,7 +15,7 @@ import (
 var (
 	db      *sql.DB
 	driver  = flag.String("driver", "postgres", "The database driver to use")
-	connect = flag.String("connect", "dbname=nnev host=/var/run/postgresql sslmode=disable", "The connection string to use")
+	connect = flag.String("connect", "", "The connection string to use")
 )
 
 func openDB() (err error) {

--- a/c14h/main.go
+++ b/c14h/main.go
@@ -21,7 +21,7 @@ import (
 var (
 	addr    = flag.String("listen", "0.0.0.0:6725", "The address to listen on")
 	driver  = flag.String("driver", "postgres", "The database driver to use")
-	connect = flag.String("connect", "dbname=nnev host=/var/run/postgresql sslmode=disable", "The connection string to use")
+	connect = flag.String("connect", "", "The connection string to use")
 	gettpl  = flag.String("template", "/var/www/www.noname-ev.de/edit_c14.html", "The template to serve for editing c¼")
 	hook    = flag.String("hook", "", "A hook to run on every change")
 

--- a/data/data.go
+++ b/data/data.go
@@ -14,7 +14,10 @@ import (
 
 var (
 	driver  = flag.String("driver", "postgres", "Der benutzte sql-Treiber")
-	connect = flag.String("connect", "dbname=nnev user=anon host=/var/run/postgresql sslmode=disable", "Die Verbindungsspezifikation")
+
+	// If the connection string is empty, the postgres driver will extract the
+	// config out of environment variables (PGHOST, PGUSER, PGDATABASE, ...).
+	connect = flag.String("connect", "", "Die Verbindungsspezifikation")
 )
 
 // OpenDB opens a connection to the database with parameters derived from flags.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 cd /tmp/go/src/github.com/nnev/website/www
-termine -hook=/build_website.sh -connect="dbname=nnev host=$PGHOST sslmode=disable" next 4
+termine -hook=/build_website.sh next 4
 jekyll build
 exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/nnev-website-supervisor.conf
+++ b/nnev-website-supervisor.conf
@@ -5,13 +5,13 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:c14h]
-command=/tmp/go/bin/c14h -template=/tmp/go/src/github.com/nnev/website/www/_site/edit_c14.html -listen=localhost:6725 -connect="dbname=nnev host=%(ENV_PGHOST)s sslmode=disable" -hook=/build_website.sh
+command=/tmp/go/bin/c14h -template=/tmp/go/src/github.com/nnev/website/www/_site/edit_c14.html -listen=localhost:6725 -hook=/build_website.sh
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:yarpnarp]
-command=/tmp/go/bin/yarpnarp -template=/tmp/go/src/github.com/nnev/website/www/_site/yarpnarp.html -listen=localhost:5417 -connect="dbname=nnev host=%(ENV_PGHOST)s sslmode=disable" -hook=/build_website.sh
+command=/tmp/go/bin/yarpnarp -template=/tmp/go/src/github.com/nnev/website/www/_site/yarpnarp.html -listen=localhost:5417 -hook=/build_website.sh
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/yarpnarp/main.go
+++ b/yarpnarp/main.go
@@ -19,7 +19,7 @@ import (
 var (
 	addr    = flag.String("listen", "0.0.0.0:5417", "The address to listen on")
 	driver  = flag.String("driver", "postgres", "The database driver to use")
-	connect = flag.String("connect", "dbname=nnev host=/var/run/postgresql sslmode=disable", "The connection string to use")
+	connect = flag.String("connect", "", "The connection string to use")
 	gettpl  = flag.String("template", "/var/www/www.noname-ev.de/yarpnarp.html", "The template to serve for editing zusagen")
 	hook    = flag.String("hook", "", "A hook to run on every change")
 


### PR DESCRIPTION
This PR should fix #70. The change is rather simple, because this is already the default behaviour of the postgres driver when the connection string is empty.