### PR TITLE
make sidebar more compact

### DIFF
--- a/www/_includes/termine.md
+++ b/www/_includes/termine.md
@@ -4,7 +4,7 @@
 
 	<b>Datum: {{ termin.date | escape }}</b> um 19 Uhr<br>
 	{% if termin.override != "" %}
-		{{ termin.override | escape | linkify }}<br>
+		{{ termin.override | escape | linkify }}
 	{% elsif termin.stammtisch %}
 		<a href="stammtisch.html">Stammtisch</a><br/>
 		<a href="yarpnarp.html">bitte zu/absagen</a><br/>

--- a/www/_includes/termine.md
+++ b/www/_includes/termine.md
@@ -5,7 +5,6 @@
 	<b>Datum: {{ termin.date | escape }}</b> um 19 Uhr<br>
 	{% if termin.override != "" %}
 		{{ termin.override | escape | linkify }}<br>
-		{{ termin.override_long | markdownify }}
 	{% elsif termin.stammtisch %}
 		<a href="stammtisch.html">Stammtisch</a><br/>
 		<a href="yarpnarp.html">bitte zu/absagen</a><br/>


### PR DESCRIPTION
Da wir den `override_long` jetzt auf der Homepage haben, muss der nicht unbedingt in die Termine-Seitenleiste rein, was die Seitenleiste wieder etwas kompakter macht. no hard feelings about the change though.