### PR TITLE
Remove Stammitsch-filter when adding talks for the time being

### DIFF
--- a/c14h/main.go
+++ b/c14h/main.go
@@ -228,7 +228,8 @@ func handlePost(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !date.IsZero() && date.Day() < 8 {
+	// TODO: roll back to if !date.IsZero() && date.Day() < 8 { once Stammtisch is a thing again
+	if !date.IsZero() {
 		writeError(400, res, "This is the first thursday of the month. Since we currently have our Stammtisch there, you can't give a talk.")
 		return
 	}

--- a/www/_plugins/linkify.rb
+++ b/www/_plugins/linkify.rb
@@ -4,7 +4,7 @@ module Jekyll
   module LinkifyFilter
     def linkify(input)
       re = Regexp.new "(https://[^ ]+)", Regexp::MULTILINE
-      input.gsub re, '<a href="\1">\1</a>'
+      input.gsub re, '<a href="\1" data-no-turbolink>\1</a>'
     end
   end
 end


### PR DESCRIPTION
Currently we don't have Stammtisch, therefore there is no point of not having Talks on that date, hence removing the check for now.